### PR TITLE
Group dependencies by feature

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -38,10 +38,10 @@ enablePlugins(AkkaGrpcPlugin)
 libraryDependencies ++= Seq(
   // 1. Basic dependencies for a clustered application
   "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
-  "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
   "com.typesafe.akka" %% "akka-cluster-typed" % AkkaVersion,
   "com.typesafe.akka" %% "akka-cluster-sharding-typed" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
+  "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
 
   // Akka Management powers Health Checks and Akka Cluster Bootstrapping
   "com.lightbend.akka.management" %% "akka-management" % AkkaManagementVersion,
@@ -59,18 +59,18 @@ libraryDependencies ++= Seq(
   // 2. Using gRPC and/or protobuf
   "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion,
 
-  // 3. Using Akka Persistence (assumes the app is clustered so event-sourced behaviors can be sharded)
+  // 3. Using Akka Persistence
   "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion,
   "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion,
   "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion,
   "com.typesafe.akka" %% "akka-persistence-testkit" % AkkaVersion % Test,
 
-  // 4. Querying or projecting data from Akka Persistence (assumes the app is clustered so projections can be sharded)
+  // 4. Querying or projecting data from Akka Persistence
   "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
   "com.lightbend.akka" %% "akka-projection-eventsourced" % AkkaProjectionVersion,
   "com.lightbend.akka" %% "akka-projection-cassandra" % AkkaProjectionVersion,
-  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test,
   "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
+  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test,
 )
 
 

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -24,13 +24,19 @@ resolvers += Resolver.bintrayRepo("akka", "snapshots")
 resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 
 
-// 1. Basic dependencies for a clustered application
 // FIXME once akka 2.6.9 is released
 val AkkaVersion = "2.6.8+71-57fb9e90"
 val AkkaHttpVersion = "10.2.0"
 // FIXME once akka management 1.0.9 is released
 val AkkaManagementVersion = "1.0.8+35-9feaa689+20200825-1429"
+val AkkaPersistenceCassandraVersion = "1.0.1"
+val AlpakkaKafkaVersion = "2.0.4"
+val AkkaProjectionVersion = "1.0.0-RC3"
+
+enablePlugins(AkkaGrpcPlugin)
+
 libraryDependencies ++= Seq(
+  // 1. Basic dependencies for a clustered application
   "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
   "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
   "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
@@ -38,43 +44,33 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-cluster-sharding-typed" % AkkaVersion,
 
   // Akka Management powers Health Checks and Akka Cluster Bootstrapping
-  "com.lightbend.akka.management" %% "akka-management" % AkkaManagementVersion, // uses Akka HTTP and Spray JSON
+  "com.lightbend.akka.management" %% "akka-management" % AkkaManagementVersion,
   "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
   "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-  "com.lightbend.akka.management" %% "akka-management-cluster-http" % AkkaManagementVersion, // cluster health-checks
-  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % AkkaManagementVersion, // cluster bootstrap
-  "com.typesafe.akka" %% "akka-discovery" % AkkaVersion, // used in cluster bootstrapping
+  "com.lightbend.akka.management" %% "akka-management-cluster-http" % AkkaManagementVersion,
+  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % AkkaManagementVersion,
+  "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
 
   // Common dependencies for logging and testing
   "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "org.scalatest" %% "scalatest" % "3.1.2" % Test,
-)
 
-// 2. Using gRPC and/or protobuf
-enablePlugins(AkkaGrpcPlugin)
-libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion, // HTTP/2 is required for gRPC
-)
+  // 2. Using gRPC and/or protobuf
+  "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion,
 
-// 3. Using Akka Persistence (assumes the app is clustered so event-sourced behaviors can be sharded)
-val AkkaPersistenceCassandraVersion = "1.0.1"
-libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion, // Akka Persistence API
-  "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion, // Recommended serializers for Persistence (CBOR)
-  "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion, // plugin implementation
+  // 3. Using Akka Persistence (assumes the app is clustered so event-sourced behaviors can be sharded)
+  "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion,
   "com.typesafe.akka" %% "akka-persistence-testkit" % AkkaVersion % Test,
-)
 
-// 4. Querying or projecting data from Akka Persistence (assumes the app is clustered so projections can be sharded)
-val AlpakkaKafkaVersion = "2.0.4"
-val AkkaProjectionVersion = "1.0.0-RC3"
-libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion, // low-level querying the event journal
-  "com.lightbend.akka" %% "akka-projection-eventsourced" % AkkaProjectionVersion, // journal as a projection source
+  // 4. Querying or projecting data from Akka Persistence (assumes the app is clustered so projections can be sharded)
+  "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
+  "com.lightbend.akka" %% "akka-projection-eventsourced" % AkkaProjectionVersion,
   "com.lightbend.akka" %% "akka-projection-cassandra" % AkkaProjectionVersion,
   "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test,
-  "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion, // Kafka as Source and Sink
+  "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
 )
 
 

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,14 +1,3 @@
-// FIXME once akka 2.6.9 is released
-val AkkaVersion = "2.6.8+71-57fb9e90"
-val AkkaPersistenceCassandraVersion = "1.0.1"
-val AlpakkaKafkaVersion = "2.0.4"
-val AkkaHttpVersion = "10.2.0"
-// FIXME once akka management 1.0.9 is released
-val AkkaManagementVersion = "1.0.8+35-9feaa689+20200825-1429"
-val AkkaProjectionVersion = "1.0.0-RC3"
-
-enablePlugins(AkkaGrpcPlugin)
-
 name := "$name$"
 version := "1.0"
 
@@ -16,10 +5,7 @@ organization := "com.lightbend.akka.samples"
 organizationHomepage := Some(url("https://akka.io"))
 licenses := Seq(("CC0", url("https://creativecommons.org/publicdomain/zero/1.0")))
 
-// For akka management snapshot
-resolvers += Resolver.bintrayRepo("akka", "snapshots")
-// For akka nightlies
-resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
+scalaVersion := "2.13.3"
 
 Compile / scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xlog-reflective-calls", "-Xlint")
 Compile / javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation")
@@ -28,34 +14,67 @@ Test / parallelExecution := false
 Test / testOptions += Tests.Argument("-oDF")
 Test / logBuffered := false
 
-scalaVersion := "2.13.3"
-
-libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-cluster-sharding-typed" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion,
-  "com.lightbend.akka" %% "akka-projection-eventsourced" % AkkaProjectionVersion,
-  "com.lightbend.akka" %% "akka-projection-cassandra" % AkkaProjectionVersion,
-  "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-  "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion,
-  "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
-  "com.lightbend.akka.management" %% "akka-management" % AkkaManagementVersion,
-  "com.lightbend.akka.management" %% "akka-management-cluster-http" % AkkaManagementVersion,
-  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % AkkaManagementVersion,
-  "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
-  // Logging
-  "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-  "ch.qos.logback" % "logback-classic" % "1.2.3",
-  // Test dependencies
-  "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
-  "com.typesafe.akka" %% "akka-persistence-testkit" % AkkaVersion % Test,
-  "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
-  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test,
-  "org.scalatest" %% "scalatest" % "3.1.2" % Test)
-
 run / fork := false
 Global / cancelable := false // ctrl-c
+
+
+// For akka management snapshot
+resolvers += Resolver.bintrayRepo("akka", "snapshots")
+// For akka nightlies
+resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
+
+
+// 1. Basic dependencies for a clustered application
+// FIXME once akka 2.6.9 is released
+val AkkaVersion = "2.6.8+71-57fb9e90"
+val AkkaHttpVersion = "10.2.0"
+// FIXME once akka management 1.0.9 is released
+val AkkaManagementVersion = "1.0.8+35-9feaa689+20200825-1429"
+libraryDependencies ++= Seq(
+  "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
+  "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
+  "com.typesafe.akka" %% "akka-cluster-typed" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-cluster-sharding-typed" % AkkaVersion,
+
+  // Akka Management powers Health Checks and Akka Cluster Bootstrapping
+  "com.lightbend.akka.management" %% "akka-management" % AkkaManagementVersion, // uses Akka HTTP and Spray JSON
+  "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+  "com.typesafe.akka" %% "akka-http-spray-json" % AkkaHttpVersion,
+  "com.lightbend.akka.management" %% "akka-management-cluster-http" % AkkaManagementVersion, // cluster health-checks
+  "com.lightbend.akka.management" %% "akka-management-cluster-bootstrap" % AkkaManagementVersion, // cluster bootstrap
+  "com.typesafe.akka" %% "akka-discovery" % AkkaVersion, // used in cluster bootstrapping
+
+  // Common dependencies for logging and testing
+  "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
+  "ch.qos.logback" % "logback-classic" % "1.2.3",
+  "org.scalatest" %% "scalatest" % "3.1.2" % Test,
+)
+
+// 2. Using gRPC and/or protobuf
+enablePlugins(AkkaGrpcPlugin)
+libraryDependencies ++= Seq(
+  "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion, // HTTP/2 is required for gRPC
+)
+
+// 3. Using Akka Persistence (assumes the app is clustered so event-sourced behaviors can be sharded)
+val AkkaPersistenceCassandraVersion = "1.0.1"
+libraryDependencies ++= Seq(
+  "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion, // Akka Persistence API
+  "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion, // Recommended serializers for Persistence (CBOR)
+  "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion, // plugin implementation
+  "com.typesafe.akka" %% "akka-persistence-testkit" % AkkaVersion % Test,
+)
+
+// 4. Querying or projecting data from Akka Persistence (assumes the app is clustered so projections can be sharded)
+val AlpakkaKafkaVersion = "2.0.4"
+val AkkaProjectionVersion = "1.0.0-RC3"
+libraryDependencies ++= Seq(
+  "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion, // low-level querying the event journal
+  "com.lightbend.akka" %% "akka-projection-eventsourced" % AkkaProjectionVersion, // journal as a projection source
+  "com.lightbend.akka" %% "akka-projection-cassandra" % AkkaProjectionVersion,
+  "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test,
+  "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion, // Kafka as Source and Sink
+)
+
+


### PR DESCRIPTION
Simplifies cleanup and understanding for new users. This PR introduces 3 changes

1. groups dependencies into `basic`, `gRPC`, `persistence` and `projection`
2. moves each version declaration closer to where it's required
3. comments some of the dependencies

I'm divided about the general change:

* on one hand, I prefer this since it makes the dependency cleanup faster
* on the other hand, the comments can be noise for users beyond the entry-level using the template

Maybe we should only do steps `1.` and `2.` (but keep the comments out of this improvement).