### PR TITLE
Add command alias to ease local node start

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -69,4 +69,6 @@ libraryDependencies ++= Seq(
   "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test,
 )
 
-
+addCommandAlias("runNode1", "run local1.conf")
+addCommandAlias("runNode2", "run local2.conf")
+addCommandAlias("runNode3", "run local3.conf")

--- a/src/main/g8/src/main/scala/$package$/Main.scala
+++ b/src/main/g8/src/main/scala/$package$/Main.scala
@@ -1,5 +1,8 @@
 package $package$
 
+import com.typesafe.config.ConfigFactory
+import org.slf4j.LoggerFactory
+
 import akka.actor.typed.scaladsl.AbstractBehavior
 import akka.actor.typed.scaladsl.ActorContext
 import akka.actor.typed.scaladsl.Behaviors
@@ -10,8 +13,20 @@ import akka.management.scaladsl.AkkaManagement
 
 object Main {
 
+  val logger = LoggerFactory.getLogger(getClass)
+  
   def main(args: Array[String]): Unit = {
-    ActorSystem[Nothing](Main(), "$name;format="word-space,upper-camel"$")
+
+    val serviceName = "$name;format="word-space,upper-camel"$"
+    
+    if (args.nonEmpty) {
+      // if an argument is passed, it's expected to be an alternative config file
+      val configToLoad = args(0)
+      logger.info(s"Actor system will be initialized with configuration file [\$configToLoad]")
+      ActorSystem[Nothing](Main(), serviceName, ConfigFactory.load(configToLoad))
+    } else {
+      ActorSystem[Nothing](Main(), serviceName)
+    }
   }
 
   def apply(): Behavior[Nothing] = {


### PR DESCRIPTION
This adds three sbt `addCommandAlias` to ease the bootstrap of local nodes during development. The Main function is then adapted to take the config as argument and start the actor system with that config.

Having to pass `-Dconfig.resource=localX.conf` when starting sbt is annoying and forces the user to learn and remember this. 

What I expect from a basic workflow is the following:

1. user start sbt
2. user run `~compile` and/or `~test` / `~testQuick`, etc. 
3. user then wants to see the application running, they can then call `runNode1`, `runNode2`, `runNode3`. 

Without that, users need to quit sbt and load it again passing `-Dconfig.resource=localX.conf` if they haven't done so before.

In addition to the pre-defined command aliases, users can add their own, but also call `run someother-config.conf` themselves.