### PR TITLE
add persistence.conf, #9

### DIFF
--- a/src/main/g8/src/main/resources/application.conf
+++ b/src/main/g8/src/main/resources/application.conf
@@ -1,6 +1,7 @@
 include "cluster"
 include "grpc"
 include "serialization"
+#include "persistence"
 
 akka {
   loglevel = DEBUG

--- a/src/main/g8/src/main/resources/persistence.conf
+++ b/src/main/g8/src/main/resources/persistence.conf
@@ -1,0 +1,44 @@
+akka {
+  # use Cassandra to store both snapshots and the events of the persistent actors
+  persistence {
+    journal.plugin = "akka.persistence.cassandra.journal"
+    journal.auto-start-journals = ["akka.persistence.cassandra.journal"]
+    snapshot-store.plugin = "akka.persistence.cassandra.snapshot"
+
+    cassandra {
+      events-by-tag {
+        bucket-size = "Day"
+        eventual-consistency-delay = 2s
+        flush-interval = 50ms
+        pubsub-notification = on
+        first-time-bucket = "20200815T00:00"
+      }
+
+      query {
+        refresh-interval = 2s
+      }
+
+      journal.keyspace = "$name;format="word-only,lowercase"$"
+      snapshot.keyspace = "$name;format="word-only,lowercase"$"
+    }
+  }
+
+  projection {
+    cassandra.offset-store.keyspace = "$name;format="word-only,lowercase"$"
+    # use same Cassandra session config as for the journal
+    cassandra.session-config-path = "akka.persistence.cassandra"
+  }
+}
+
+datastax-java-driver {
+  advanced.reconnect-on-init = on
+}
+
+akka.management {
+  health-checks {
+    readiness-checks {
+      akka-persistence-cassandra = "akka.persistence.cassandra.healthcheck.CassandraHealthCheck"
+    }
+  }
+}
+


### PR DESCRIPTION
* because then we can remove a rather meaningless copy paste from the tutorial
* but it's not included from application.conf because it should be possible
  to start with gRPC service without database


References #9
